### PR TITLE
targetDatasets options added and used for filtering datasets to be do…

### DIFF
--- a/src/chartjs-plugin-downsample.js
+++ b/src/chartjs-plugin-downsample.js
@@ -19,6 +19,9 @@ var defaultOptions = {
     // if true, downsamples original data instead of data
     preferOriginalData: false,
 
+    //if not undefined and not empty, indicates the ids of the datasets to downsample
+    targetDatasets : []
+
 };
 
 var floor = Math.floor,
@@ -99,12 +102,19 @@ function getOptions(chartInstance) {
     return chartInstance.options.downsample;
 }
 
+function getFilteredDatasets(chartInstance){
+    var options = getOptions(chartInstance)
+    var datasets = options.targetDatasets.length == 0 ? chartInstance.data.datasets : 
+        chartInstance.data.datasets.filter(d => options.targetDatasets.find(targetId => targetId == d.id));
+    return datasets;
+}
+
 function downsampleChart(chartInstance) {
     var options = getOptions(chartInstance),
         threshold = options.threshold;
     if(!options.enabled) return;
 
-    var datasets = chartInstance.data.datasets;
+    var datasets = getFilteredDatasets(chartInstance);
     for(var i = 0; i < datasets.length; i++) {
         var dataset = datasets[i];
 
@@ -147,7 +157,7 @@ var downsamplePlugin = {
         var options = getOptions(chartInstance);
         if(!options.enabled || !options.restoreOriginalData) return;
 
-        var datasets = chartInstance.data.datasets;
+    var datasets = getFilteredDatasets(chartInstance);
         for(var i = 0; i < datasets.length; i++) {
             var dataset = datasets[i];
 


### PR DESCRIPTION
I would like to include this feature in the plugin. 
Usage (config):

```
var config = {
 ...
 downsample : {
      ...,
      targetDatasets : [id1,id2, ..., idN]
  }
}
```

so that only datasets having id within `targetDatasets` will be downsampled